### PR TITLE
feat: add vi mode, selection, and indicator statusline colors

### DIFF
--- a/catppuccin.yml
+++ b/catppuccin.yml
@@ -33,6 +33,25 @@ color_schemes:
             magenta: "#EA76CB" # pink
             cyan: "#179299" # teal
             white: "#BCC0CC" # surface1
+
+        # Vi mode colors
+        vi_mode_highlight:
+            foreground: CellForeground
+            background: "#EFF1F5" # base
+        vi_mode_cursorline:
+            foreground: CellForeground
+            background: "#ACB0BE" # surface2
+            background_alpha: 0.1
+
+        # Selection colors
+        selection:
+            foreground: CellForeground
+            background: "#ACB0BE" # surface2
+
+        # Indicator status line colors
+        indicator_statusline:
+            foreground: CellForeground
+            background: "#1E66F5" # blue
     catppuccin_frappe:
         # Default colours
         default:
@@ -65,6 +84,25 @@ color_schemes:
             magenta: "#F4B8E4" # pink
             cyan: "#81C8BE" # teal
             white: "#A5ADCE" # subtext0
+
+        # Vi mode colors
+        vi_mode_highlight:
+            foreground: CellForeground
+            background: "#303446" # base
+        vi_mode_cursorline:
+            foreground: CellForeground
+            background: "#626880" # surface2
+            background_alpha: 0.1
+
+        # Selection colors
+        selection:
+            foreground: CellForeground
+            background: "#626880" # surface2
+
+        # Indicator status line colors
+        indicator_statusline:
+            foreground: CellForeground
+            background: "#8CAAEE" # blue
     catppuccin_macchiato:
         # Default colours
         default:
@@ -97,6 +135,25 @@ color_schemes:
             magenta: "#F5BDE6" # pink
             cyan: "#8BD5CA" # teal
             white: "#A5ADCB" # subtext0
+
+        # Vi mode colors
+        vi_mode_highlight:
+            foreground: CellForeground
+            background: "#24273A" # base
+        vi_mode_cursorline:
+            foreground: CellForeground
+            background: "#5B6078" # surface2
+            background_alpha: 0.1
+
+        # Selection colors
+        selection:
+            foreground: CellForeground
+            background: "#5B6078" # surface2
+
+        # Indicator status line colors
+        indicator_statusline:
+            foreground: CellForeground
+            background: "#8AADF4" # blue
     catppuccin_mocha:
         # Default colours
         default:
@@ -129,4 +186,22 @@ color_schemes:
             magenta: "#F5C2E7" # pink
             cyan: "#94E2D5" # teal
             white: "#A6ADC8" # subtext0
-    
+
+        # Vi mode colors
+        vi_mode_highlight:
+            foreground: CellForeground
+            background: "#1E1E2E" # base
+        vi_mode_cursorline:
+            foreground: CellForeground
+            background: "#585B70" # surface2
+            background_alpha: 0.1
+
+        # Selection colors
+        selection:
+            foreground: CellForeground
+            background: "#585B70" # surface2
+
+        # Indicator status line colors
+        indicator_statusline:
+            foreground: CellForeground
+            background: "#89B4FA" # blue


### PR DESCRIPTION
Using Vi mode inside `contour` is ugly so here's what I'm currently having in my config file.
This is also incomplete because there is "search mode" that I'm not using so I don't include it in this PR.
Here's the screenshot of the `catppuccin_mocha` in visual mode with text selected, I follow `neovim` with `lualine` colorscheme.
![image](https://github.com/user-attachments/assets/bf603871-bbe4-43cf-bf08-7ca0dbf9e5aa)